### PR TITLE
bug/6-yhkim to develop

### DIFF
--- a/mosaic-ros2-sensor/include/mosaic-ros2-sensor/connector/point_cloud2_connector.hpp
+++ b/mosaic-ros2-sensor/include/mosaic-ros2-sensor/connector/point_cloud2_connector.hpp
@@ -44,19 +44,24 @@ namespace mosaic::ros2::sensor_connector {
 
         virtual void SetParams(const std::unordered_map<std::string, std::string> &params) = 0;
 
-        virtual void ProcessAsync(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) = 0;
+        void ProcessAsync(const sensor_msgs::msg::PointCloud2::SharedPtr &msg);
 
     protected:
-        bool IsAllChannelReady() const;
+        virtual void ProcessMsg(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) = 0;
 
         std::shared_ptr<PointCloud2DataChannel> GetNextChannel(int retry_count);
 
         void SendData(const std::string &data);
 
     private:
+        bool IsAllChannelReady() const;
+
+        bool sending_ = false;
+        std::mutex mutex_;
+
         int channel_idx_ = 0;
         int max_channel_idx_ = 0;
-        std::vector<std::shared_ptr<PointCloud2DataChannel> > point_cloud_2_data_channels_;
+        std::vector<std::shared_ptr<PointCloud2DataChannel> > data_channels_;
     };
 
     class PointCloud2DataChannel : public handlers::DataChannelSendable {

--- a/mosaic-ros2-sensor/include/mosaic-ros2-sensor/util/progressive_point_cloud2_sender.hpp
+++ b/mosaic-ros2-sensor/include/mosaic-ros2-sensor/util/progressive_point_cloud2_sender.hpp
@@ -113,6 +113,7 @@ namespace mosaic::ros2::sensor_connector {
         std::unique_ptr<PointCloudConfig> config_;
 
         float voxel_size_ = 0.5; // Minimum voxel size for octree leaf nodes (m)
+        size_t min_points_to_subdivide_ = 10;
     };
 } // namespace mosaic::ros2::sensor_connector
 

--- a/mosaic-ros2-sensor/include/mosaic-ros2-sensor/util/progressive_point_cloud2_sender.hpp
+++ b/mosaic-ros2-sensor/include/mosaic-ros2-sensor/util/progressive_point_cloud2_sender.hpp
@@ -18,12 +18,11 @@ namespace mosaic::ros2::sensor_connector {
 
         void SetParams(const std::unordered_map<std::string, std::string> &params) override;
 
-        void ProcessAsync(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) override;
+    protected:
+        void ProcessMsg(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) override;
 
     private:
         struct OctreeNode;
-
-        void SendInternal(const sensor_msgs::msg::PointCloud2::SharedPtr &msg);
 
         std::shared_ptr<ProgressivePointCloud::Meta> ExtractMeta(
             const sensor_msgs::msg::PointCloud2::SharedPtr &msg) const;
@@ -111,9 +110,6 @@ namespace mosaic::ros2::sensor_connector {
         };
 
         bool initialized_ = false;
-        bool try_sending = false;
-        std::mutex mutex_;
-
         std::unique_ptr<PointCloudConfig> config_;
 
         float voxel_size_ = 0.5; // Minimum voxel size for octree leaf nodes (m)

--- a/mosaic-ros2-sensor/include/mosaic-ros2-sensor/util/simple_point_cloud2_sender.hpp
+++ b/mosaic-ros2-sensor/include/mosaic-ros2-sensor/util/simple_point_cloud2_sender.hpp
@@ -65,7 +65,6 @@ namespace mosaic::ros2::sensor_connector {
             uint32_t point_step; // Byte size of one point
             size_t max_points_per_chunk; // Maximum points per chunk
             size_t total_points; // Total number of points
-            size_t estimated_chunks_per_level; // Estimated chunks per level
         };
 
         bool initialized_ = false;

--- a/mosaic-ros2-sensor/include/mosaic-ros2-sensor/util/simple_point_cloud2_sender.hpp
+++ b/mosaic-ros2-sensor/include/mosaic-ros2-sensor/util/simple_point_cloud2_sender.hpp
@@ -16,13 +16,13 @@ namespace mosaic::ros2::sensor_connector {
 
         ~SimplePointCloud2Sender() override = default;
 
-        void SetParams(const std::unordered_map<std::string, std::string> &) override {}
+        void SetParams(const std::unordered_map<std::string, std::string> &) override {
+        }
 
-        void ProcessAsync(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) override;
+    protected:
+        void ProcessMsg(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) override;
 
     private:
-        void SendInternal(const sensor_msgs::msg::PointCloud2::SharedPtr &msg);
-
         std::shared_ptr<ProgressivePointCloud::Meta> ExtractMeta(
             const sensor_msgs::msg::PointCloud2::SharedPtr &msg) const;
 
@@ -69,9 +69,6 @@ namespace mosaic::ros2::sensor_connector {
         };
 
         bool initialized_ = false;
-        bool try_sending = false;
-        std::mutex mutex_;
-
         std::unique_ptr<PointCloudConfig> config_;
     };
 } // namespace mosaic::ros2::sensor_connector

--- a/mosaic-ros2-sensor/src/connector/point_cloud2_connector.cpp
+++ b/mosaic-ros2-sensor/src/connector/point_cloud2_connector.cpp
@@ -52,16 +52,45 @@ void PointCloud2ConnectorConfigurer::Callback(sensor_msgs::msg::PointCloud2::Sha
 }
 
 void PointCloud2Sender::AddPointCloud2DataChannel(const std::shared_ptr<PointCloud2DataChannel> &channel) {
-    point_cloud_2_data_channels_.push_back(channel);
+    data_channels_.push_back(channel);
     max_channel_idx_++;
     MOSAIC_LOG_INFO("Add data channel: {}", max_channel_idx_);
 }
 
+void PointCloud2Sender::ProcessAsync(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) {
+    {
+        std::lock_guard lock(mutex_);
+        if (sending_ == true) {
+            MOSAIC_LOG_ERROR("Frame drop!");
+            return;
+        }
+
+        if (!IsAllChannelReady()) {
+            MOSAIC_LOG_VERBOSE("Not all channel ready!");
+            return;
+        }
+        sending_ = true;
+    }
+
+    std::thread([this, msg] {
+        try {
+            this->ProcessMsg(msg);
+        } catch (const std::runtime_error &e) {
+            MOSAIC_LOG_ERROR("[PointCloud2Sender] Error while ProcessMsg: {}", e.what());
+        }
+
+        {
+            std::lock_guard lock(mutex_);
+            sending_ = false;
+        }
+    }).detach();
+}
+
 bool PointCloud2Sender::IsAllChannelReady() const {
-    if (point_cloud_2_data_channels_.empty()) {
+    if (data_channels_.empty()) {
         return false;
     }
-    for (const auto &channel: point_cloud_2_data_channels_) {
+    for (const auto &channel: data_channels_) {
         if (channel->Sendable()) {
             return true;
         }
@@ -72,8 +101,8 @@ bool PointCloud2Sender::IsAllChannelReady() const {
 std::shared_ptr<PointCloud2DataChannel> PointCloud2Sender::GetNextChannel(int retry_count) {
     channel_idx_++;
     channel_idx_ %= max_channel_idx_;
-    if (point_cloud_2_data_channels_[channel_idx_]->Sendable()) {
-        return point_cloud_2_data_channels_[channel_idx_];
+    if (data_channels_[channel_idx_]->Sendable()) {
+        return data_channels_[channel_idx_];
     }
     if (retry_count > 10) {
         MOSAIC_LOG_ERROR("Failed to get next channel after 10 retries!");

--- a/mosaic-ros2-sensor/src/util/progressive_point_cloud2_sender.cpp
+++ b/mosaic-ros2-sensor/src/util/progressive_point_cloud2_sender.cpp
@@ -23,6 +23,9 @@ void ProgressivePointCloud2Sender::SetParams(const std::unordered_map<std::strin
     if (params.find("voxel_size") != params.end()) {
         voxel_size_ = std::stof(params.at("voxel_size"));
     }
+    if (params.find("min_points_to_subdivide") != params.end()) {
+        min_points_to_subdivide_ = std::stoi(params.at("min_points_to_subdivide"));
+    }
 }
 
 void ProgressivePointCloud2Sender::ProcessMsg(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) {
@@ -209,14 +212,6 @@ void ProgressivePointCloud2Sender::Initialize(const sensor_msgs::msg::PointCloud
     // Calculate maximum points per chunk
     config_->max_points_per_chunk = MAX_CHUNK_SIZE_BYTES / config_->point_step;
 
-    // Calculate estimated chunks per level
-    // Divide total points into 5 levels and estimate required chunks per level
-    // TODO: NUM_LEVELS and data channel size??
-    constexpr size_t NUM_LEVELS = 5;
-    const size_t avg_points_per_level = config_->total_points / NUM_LEVELS;
-    config_->estimated_chunks_per_level =
-            (avg_points_per_level + config_->max_points_per_chunk - 1) / config_->max_points_per_chunk;
-
     initialized_ = true;
 }
 
@@ -337,8 +332,7 @@ std::unique_ptr<ProgressivePointCloud2Sender::OctreeNode> ProgressivePointCloud2
 }
 
 void ProgressivePointCloud2Sender::SubdivideNode(OctreeNode *node, std::vector<PointData> points) {
-    constexpr size_t MIN_POINTS_TO_SUBDIVIDE = 10;
-    if (points.size() <= MIN_POINTS_TO_SUBDIVIDE || node->get_size() <= voxel_size_) {
+    if (points.size() <= min_points_to_subdivide_ || node->get_size() <= voxel_size_) {
         node->point_indices.reserve(points.size());
         for (const auto &pd: points) {
             node->point_indices.push_back(pd.index);

--- a/mosaic-ros2-sensor/src/util/progressive_point_cloud2_sender.cpp
+++ b/mosaic-ros2-sensor/src/util/progressive_point_cloud2_sender.cpp
@@ -13,7 +13,6 @@
 #include <cstring>
 #include <limits>
 #include <stdexcept>
-#include <thread>
 #include <vector>
 
 #include <mosaic/handlers/data_channel/data_channel_handler.hpp>
@@ -26,32 +25,10 @@ void ProgressivePointCloud2Sender::SetParams(const std::unordered_map<std::strin
     }
 }
 
-void ProgressivePointCloud2Sender::ProcessAsync(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) {
-    std::thread([this, msg] {
-        this->SendInternal(msg);
-    }).detach();
-}
-
-void ProgressivePointCloud2Sender::SendInternal(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) {
-    {
-        std::lock_guard lock(mutex_);
-        if (try_sending == true) {
-            MOSAIC_LOG_ERROR("Frame drop!");
-            return;
-        }
-        try_sending = true;
-
-        // Initialize the first frame
-        if (!initialized_) {
-            config_ = std::make_unique<PointCloudConfig>();
-            Initialize(msg);
-        }
-
-        if (!IsAllChannelReady()) {
-            MOSAIC_LOG_VERBOSE("Not all channel ready!");
-            try_sending = false;
-            return;
-        }
+void ProgressivePointCloud2Sender::ProcessMsg(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) {
+    if (!initialized_) {
+        config_ = std::make_unique<PointCloudConfig>();
+        Initialize(msg);
     }
 
     const long created_timestamp = utils::GetNow();
@@ -69,11 +46,6 @@ void ProgressivePointCloud2Sender::SendInternal(const sensor_msgs::msg::PointClo
     CollectLeafNodes(octree_root.get(), leaf_nodes);
 
     SendPoints(msg, leaf_nodes, frame_id, created_timestamp);
-
-    {
-        std::lock_guard lock(mutex_);
-        try_sending = false;
-    }
 }
 
 void ProgressivePointCloud2Sender::SendPoints(const sensor_msgs::msg::PointCloud2::SharedPtr &msg,

--- a/mosaic-ros2-sensor/src/util/simple_point_cloud2_sender.cpp
+++ b/mosaic-ros2-sensor/src/util/simple_point_cloud2_sender.cpp
@@ -12,39 +12,16 @@
 #include <cstring>
 #include <limits>
 #include <stdexcept>
-#include <thread>
 #include <vector>
 
 #include <mosaic/handlers/data_channel/data_channel_handler.hpp>
 
 using namespace mosaic::ros2::sensor_connector;
 
-void SimplePointCloud2Sender::ProcessAsync(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) {
-    std::thread([this, msg] {
-        this->SendInternal(msg);
-    }).detach();
-}
-
-void SimplePointCloud2Sender::SendInternal(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) {
-    {
-        std::lock_guard lock(mutex_);
-        if (try_sending == true) {
-            MOSAIC_LOG_ERROR("Frame drop!");
-            return;
-        }
-        try_sending = true;
-
-        // Initialize the first frame
-        if (!initialized_) {
-            config_ = std::make_unique<PointCloudConfig>();
-            Initialize(msg);
-        }
-
-        if (!IsAllChannelReady()) {
-            MOSAIC_LOG_VERBOSE("Not all channel ready!");
-            try_sending = false;
-            return;
-        }
+void SimplePointCloud2Sender::ProcessMsg(const sensor_msgs::msg::PointCloud2::SharedPtr &msg) {
+    if (!initialized_) {
+        config_ = std::make_unique<PointCloudConfig>();
+        Initialize(msg);
     }
 
     const long created_timestamp = utils::GetNow();
@@ -55,11 +32,6 @@ void SimplePointCloud2Sender::SendInternal(const sensor_msgs::msg::PointCloud2::
     SendData(ppc_meta->SerializeAsString());
 
     SendPoints(msg, frame_id, created_timestamp);
-
-    {
-        std::lock_guard lock(mutex_);
-        try_sending = false;
-    }
 }
 
 void SimplePointCloud2Sender::SendPoints(const sensor_msgs::msg::PointCloud2::SharedPtr &msg,

--- a/mosaic-ros2-sensor/src/util/simple_point_cloud2_sender.cpp
+++ b/mosaic-ros2-sensor/src/util/simple_point_cloud2_sender.cpp
@@ -174,14 +174,6 @@ void SimplePointCloud2Sender::Initialize(const sensor_msgs::msg::PointCloud2::Sh
     // Calculate maximum points per chunk
     config_->max_points_per_chunk = MAX_CHUNK_SIZE_BYTES / config_->point_step;
 
-    // Calculate estimated chunks per level
-    // Divide total points into 5 levels and estimate required chunks per level
-    // TODO: NUM_LEVELS and data channel size??
-    constexpr size_t NUM_LEVELS = 5;
-    const size_t avg_points_per_level = config_->total_points / NUM_LEVELS;
-    config_->estimated_chunks_per_level =
-            (avg_points_per_level + config_->max_points_per_chunk - 1) / config_->max_points_per_chunk;
-
     initialized_ = true;
 }
 


### PR DESCRIPTION
This pull request refactors the point cloud sender classes to simplify asynchronous processing, unify channel management, and improve configurability. The main changes include centralizing async logic in the base class, updating channel naming for clarity, removing redundant threading and locking from derived classes, and making octree subdivision more configurable.

**Refactoring of Asynchronous Processing and Channel Management:**

* The `ProcessAsync` method is now implemented in the base `PointCloud2Sender` class, handling threading, locking, and channel readiness checks centrally. Derived classes now implement a protected `ProcessMsg` method for message-specific processing only. (`mosaic-ros2-sensor/include/mosaic-ros2-sensor/connector/point_cloud2_connector.hpp` [[1]](diffhunk://#diff-985e887b9bbeffe02141d9601e8dc1f45d86fdb42a0166ef56f758444a0af193L47-R64) `mosaic-ros2-sensor/src/connector/point_cloud2_connector.cpp` [[2]](diffhunk://#diff-253e6fd33143066a3f67d22db74ce24342ac9a92d342598a466ba14ace947c0cL55-R93)
* The internal vector for data channels is renamed from `point_cloud_2_data_channels_` to `data_channels_` throughout the codebase for consistency and clarity. (`mosaic-ros2-sensor/include/mosaic-ros2-sensor/connector/point_cloud2_connector.hpp` [[1]](diffhunk://#diff-985e887b9bbeffe02141d9601e8dc1f45d86fdb42a0166ef56f758444a0af193L47-R64) `mosaic-ros2-sensor/src/connector/point_cloud2_connector.cpp` [[2]](diffhunk://#diff-253e6fd33143066a3f67d22db74ce24342ac9a92d342598a466ba14ace947c0cL55-R93) [[3]](diffhunk://#diff-253e6fd33143066a3f67d22db74ce24342ac9a92d342598a466ba14ace947c0cL75-R105)

**Simplification of Derived Sender Classes:**

* Threading and mutex logic, as well as redundant internal sending state, are removed from both `ProgressivePointCloud2Sender` and `SimplePointCloud2Sender`. These classes now only implement `ProcessMsg` and related logic, relying on the base class for concurrency control. (`mosaic-ros2-sensor/include/mosaic-ros2-sensor/util/progressive_point_cloud2_sender.hpp` [[1]](diffhunk://#diff-5bf25961fa97f8e0dd2984223130eb97b76416812137efdfe1fd9e92b1b1ea40L21-L27) [[2]](diffhunk://#diff-5bf25961fa97f8e0dd2984223130eb97b76416812137efdfe1fd9e92b1b1ea40L114-R116) `mosaic-ros2-sensor/src/util/progressive_point_cloud2_sender.cpp` [[3]](diffhunk://#diff-b888bb7249827a2ae62eddc058732f4e43b1c43330137f678f5d4a181a62ebd8L16) [[4]](diffhunk://#diff-b888bb7249827a2ae62eddc058732f4e43b1c43330137f678f5d4a181a62ebd8R26-L56) [[5]](diffhunk://#diff-b888bb7249827a2ae62eddc058732f4e43b1c43330137f678f5d4a181a62ebd8L72-L76) `mosaic-ros2-sensor/include/mosaic-ros2-sensor/util/simple_point_cloud2_sender.hpp` [[6]](diffhunk://#diff-8b0113af552579de364f436f94711bc0530a3451ae6c82512f313cb2de7cadf1L19-L25) [[7]](diffhunk://#diff-8b0113af552579de364f436f94711bc0530a3451ae6c82512f313cb2de7cadf1L68-L74) `mosaic-ros2-sensor/src/util/simple_point_cloud2_sender.cpp` [[8]](diffhunk://#diff-9ce003606585067455ce1e340b18be42ad769fb5f459db444154e925168e749cL15-L49) [[9]](diffhunk://#diff-9ce003606585067455ce1e340b18be42ad769fb5f459db444154e925168e749cL58-L62)

**Configurability and Parameterization:**

* The minimum number of points to trigger octree subdivision is now configurable via the `min_points_to_subdivide` parameter, rather than being hardcoded. (`mosaic-ros2-sensor/include/mosaic-ros2-sensor/util/progressive_point_cloud2_sender.hpp` [[1]](diffhunk://#diff-5bf25961fa97f8e0dd2984223130eb97b76416812137efdfe1fd9e92b1b1ea40L114-R116) `mosaic-ros2-sensor/src/util/progressive_point_cloud2_sender.cpp` [[2]](diffhunk://#diff-b888bb7249827a2ae62eddc058732f4e43b1c43330137f678f5d4a181a62ebd8R26-L56) [[3]](diffhunk://#diff-b888bb7249827a2ae62eddc058732f4e43b1c43330137f678f5d4a181a62ebd8L368-R335)

**Code Cleanup and Removal of Unused Logic:**

* Unused or redundant members and logic, such as `estimated_chunks_per_level`, are removed from configuration structures and initialization routines. (`mosaic-ros2-sensor/include/mosaic-ros2-sensor/util/simple_point_cloud2_sender.hpp` [[1]](diffhunk://#diff-8b0113af552579de364f436f94711bc0530a3451ae6c82512f313cb2de7cadf1L68-L74) `mosaic-ros2-sensor/src/util/progressive_point_cloud2_sender.cpp` [[2]](diffhunk://#diff-b888bb7249827a2ae62eddc058732f4e43b1c43330137f678f5d4a181a62ebd8L240-L247) `mosaic-ros2-sensor/src/util/simple_point_cloud2_sender.cpp` [[3]](diffhunk://#diff-9ce003606585067455ce1e340b18be42ad769fb5f459db444154e925168e749cL205-L212)

These changes make the codebase easier to maintain, improve thread safety, and provide more flexibility for point cloud processing.